### PR TITLE
Fixed curl command in Kubernetes guide

### DIFF
--- a/_guides/kubernetes-guide.adoc
+++ b/_guides/kubernetes-guide.adoc
@@ -77,7 +77,7 @@ oc expose service quarkus-quickstart
 
 # Get the route URL
 export URL="http://$(oc get route | grep quarkus-quickstart | awk '{print $2}')"
-curl $URL/hello/greeting/quarkus
+curl $URL/hello
 ----
 
 Your application is accessible at the printed URL.


### PR DESCRIPTION
For me ```curl http://quarkus-quickstart-launcher.192.168.64.2.nip.io/hello/greeting/quarkus``` gives a 404. Where as ```curl http://quarkus-quickstart-launcher.192.168.64.2.nip.io/hello``` worked. I'm not sure if I made a mistake following the steps, or if the guide had an error.